### PR TITLE
Native Travis support for R.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,11 @@
-language: c
+language: r
 
-env:
-  global:
-      # Support for PDF manuals is not available in Travis setup.
-    - R_BUILD_ARGS='--no-manual'
-    - R_CHECK_ARGS='--no-manual'
-
-before_install:
-  - curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh
-  - chmod 755 ./travis-tool.sh
-  - ./travis-tool.sh bootstrap
-install:
-  - ./travis-tool.sh install_bioc_deps
+bioc_required: true
+bioc_use_devel: true
 
 before_script:
     # Secure auth credentials can not be made available for pull requests.
-  - if [[ $TRAVIS_PULL_REQUEST != "false" ]]; then export R_BUILD_ARGS="--no-build-vignettes --no-manual"; export R_CHECK_ARGS="--no-vignettes --no-examples --no-manual"; fi
+  - if [[ $TRAVIS_PULL_REQUEST != "false" ]]; then export R_BUILD_ARGS="--no-build-vignettes"; export R_CHECK_ARGS="--no-vignettes --no-examples"; fi
 
-script: ./travis-tool.sh run_tests
-
-after_failure:
-  - ./travis-tool.sh dump_logs
 after_success:
   - tail -n6 GoogleGenomics.Rcheck/tests/runTests.Rout
-
-notifications:
-  email:
-    on_success: change
-    on_failure: change


### PR DESCRIPTION
Uses Linux which builds packages from source and also builds manuals; running time is currently 25 mins.