### PR TITLE
Switch to native Travis (container-based) support for R.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,11 @@
-language: c
+language: r
+sudo: false
+cache: packages
 
-env:
-  global:
-      # Support for PDF manuals is not available in Travis setup.
-    - R_BUILD_ARGS='--no-manual'
-    - R_CHECK_ARGS='--no-manual'
+# Package caching only makes sense for the release versions.
+r: bioc-release
 
-before_install:
-  - curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh
-  - chmod 755 ./travis-tool.sh
-  - ./travis-tool.sh bootstrap
-install:
-  - ./travis-tool.sh install_bioc_deps
+# Secure auth credentials can not be made available for pull requests.
+r_build_args:
+r_check_args: "$(if [[ $TRAVIS_PULL_REQUEST != 'false' ]]; then echo '--no-examples'; fi)"
 
-before_script:
-    # Secure auth credentials can not be made available for pull requests.
-  - if [[ $TRAVIS_PULL_REQUEST != "false" ]]; then export R_BUILD_ARGS="--no-build-vignettes --no-manual"; export R_CHECK_ARGS="--no-vignettes --no-examples --no-manual"; fi
-
-script: ./travis-tool.sh run_tests
-
-after_failure:
-  - ./travis-tool.sh dump_logs
-after_success:
-  - tail -n6 GoogleGenomics.Rcheck/tests/runTests.Rout
-
-notifications:
-  email:
-    on_success: change
-    on_failure: change

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -12,6 +12,9 @@ importFrom(Rsamtools, bamFlagAsBitMatrix)
 importFrom(S4Vectors, Rle)
 importFrom(VariantAnnotation, strand, VRanges)
 
+## Utility imports ##
+importFrom(utils, installed.packages)
+
 #### Exports ####
 
 ## Authentication ##


### PR DESCRIPTION
The container infrastructure was not ready the last time these Travis tests were updated. This also has pandoc installed, without which, our Travis tests were failing before.

Also contains a change to our NAMESPACE file to remove a note from package checks.